### PR TITLE
Use console.log instead of stdout

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,4 +46,4 @@ const id = cli.flags.alphabet && !equivalent(cli.flags.alphabet, url)
   ? generate(cli.flags.alphabet, cli.flags.size || 21)
   : nanoid(cli.flags.size);
 
-process.stdout.write(id);
+console.log(id);


### PR DESCRIPTION
Considering this is a cli package, it would be kinda nice to have some sort of readability within the terminal. Currently, the package uses stdout and without a new line at the end, which causes the id generated to be mashed up with the shell prompt.